### PR TITLE
Revert "fix: update helm chart zigbee2mqtt to 9.3.2"

### DIFF
--- a/k8s/clusters/cluster-1/manifests/home-automation/zigbee2mqtt/helmrelease.yaml
+++ b/k8s/clusters/cluster-1/manifests/home-automation/zigbee2mqtt/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     spec:
       chart: zigbee2mqtt
-      version: 9.3.2
+      version: 9.3.1
       sourceRef:
         kind: HelmRepository
         name: k8s-at-home-charts


### PR DESCRIPTION
Reverts dcplaya/home-ops#303

Container image wont pull this version