### PR TITLE
Revert "fix(container): update image ghcr.io/onedr0p/home-assistant to v2024.1.4"

### DIFF
--- a/k8s/clusters/cluster-1/manifests/home-automation/home-assistant/app/helmrelease.yaml
+++ b/k8s/clusters/cluster-1/manifests/home-automation/home-assistant/app/helmrelease.yaml
@@ -63,7 +63,7 @@ spec:
           main:
             image:
               repository: ghcr.io/onedr0p/home-assistant
-              tag: 2024.1.4@sha256:4191914edf44fe6dc0768e8be004864e9ab9f019b7c296f765319f675c98b90f
+              tag: 2024.1.3@sha256:f1adaefd28f877f6377487d6c4e7d7daf01db73bfcad8379314ab507b84a6666
               pullPolicy: IfNotPresent
             env:
               TZ: "${TIMEZONE}"


### PR DESCRIPTION
Reverts dcplaya/home-ops#8274

Crashes Home Assistant due to SNMP maybe?