### PR TITLE
Revert "fix(helm): update chart ingress-nginx to 4.10.2"

### DIFF
--- a/k8s/clusters/cluster-2/manifests/network/ingress-nginx/external/helmrelease.yaml
+++ b/k8s/clusters/cluster-2/manifests/network/ingress-nginx/external/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: ingress-nginx
-      version: 4.10.2
+      version: 4.10.1
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx

--- a/k8s/clusters/cluster-2/manifests/network/ingress-nginx/internal/helmrelease.yaml
+++ b/k8s/clusters/cluster-2/manifests/network/ingress-nginx/internal/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: ingress-nginx
-      version: 4.10.2
+      version: 4.10.1
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx


### PR DESCRIPTION
Reverts dcplaya/home-ops#8716
Reverting again, seems like 4.10.2 is fubar too