### PR TITLE
Revert "fix(container): update image quay.io/ceph/ceph to v18.2.4"

### DIFF
--- a/k8s/clusters/cluster-2/manifests/rook-ceph/cluster/helmrelease.yaml
+++ b/k8s/clusters/cluster-2/manifests/rook-ceph/cluster/helmrelease.yaml
@@ -50,7 +50,7 @@ spec:
               - *host
     toolbox:
       enabled: true
-      image: quay.io/ceph/ceph:v18.2.4
+      image: quay.io/ceph/ceph:v18.2.2
     configOverride: |
       [global]
       bdev_enable_discard = true
@@ -80,7 +80,7 @@ spec:
 
     cephClusterSpec:
       cephVersion:
-        image: quay.io/ceph/ceph:v18.2.4
+        image: quay.io/ceph/ceph:v18.2.2
       mgr:
         count: 2
         allowMultiplePerNode: false


### PR DESCRIPTION
Reverts dcplaya/home-ops#8739

Ceph crashes on some OSDs now