### PR TITLE
[fix] Add TLSRoute for services that need https backend

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -105,7 +105,7 @@ spec:
         # annotations:
         #   io.cilium/lb-ipam-ips: "${LB_FRIGATE}"
         ports:
-          https:
+          http:
             port: *port
           rtsp:
             enabled: true
@@ -173,11 +173,13 @@ spec:
 
     route:
       app:
-        hostnames: ["{{ .Release.Name }}.${INGRESS_DOMAIN}"]
+        kind: TLSRoute
+        hostnames:
+          - '{{ .Release.Name }}.${SECRET_DOMAIN}'
         parentRefs:
           - name: internal
             namespace: kube-system
-            sectionName: https
+            sectionName: tls
         rules:
           - backendRefs:
               - name: *app

--- a/kubernetes/apps/kube-system/cilium/gateway/internal.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/internal.yaml
@@ -36,3 +36,12 @@ spec:
       certificateRefs:
       - kind: Secret
         name: "${SECRET_DOMAIN/./-}-production-tls"
+  - name: tls
+    protocol: TLS
+    port: 443
+    hostname: "*.${SECRET_DOMAIN}"
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      mode: Passthrough

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -99,7 +99,7 @@ spec:
         annotations:
           io.cilium/lb-ipam-ips: ${LB_PLEX}
         ports:
-          https:
+          http:
             port: &port 32400
             # externalTrafficPolicy: Cluster
 


### PR DESCRIPTION
Frigate is the only one currently that requires it. Also reverted the services change since its just a namechange and did nothing