### PR TITLE
[fix] Add `TLSRoute` to internal external-dns-unifi

### DIFF
--- a/kubernetes/apps/network/internal/external-dns-unifi/helmrelease.yaml
+++ b/kubernetes/apps/network/internal/external-dns-unifi/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
           timeoutSeconds: 5
     triggerLoopOnEvent: true
     policy: sync
-    sources: [ "ingress", "service", "gateway-httproute" ]
+    sources: [ "ingress", "service", "gateway-httproute", "gateway-tlsroute" ]
     txtOwnerId: k8s.
     txtPrefix: default
     domainFilters: [ "${SECRET_DOMAIN}" ]


### PR DESCRIPTION
Should allow Frigate to sync DNS records