### PR TITLE
Revert "fix(container): update coredns group ( 1.43.0 → 1.43.2 )"

### DIFF
--- a/bootstrap/helmfile.yaml
+++ b/bootstrap/helmfile.yaml
@@ -38,7 +38,7 @@ releases:
   namespace: kube-system
   atomic: true
   chart: coredns/coredns
-  version: 1.43.2
+  version: 1.43.0
   values: [ '/home/carpenam/GitProjects/home-ops/kubernetes/apps/kube-system/coredns/app/helm/values.yaml' ]
   needs: [ 'kube-system/cilium' ]
 

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
     operation: copy
   url: oci://ghcr.io/coredns/charts/coredns
   ref:
-    tag: 1.43.2
+    tag: 1.43.0
   verify:
     provider: cosign
 ---


### PR DESCRIPTION
Reverts dcplaya/home-ops#365

CoreDNS can't be pulled for some reason.  Reverting to see if it's a version issue 